### PR TITLE
Copy over robots.txt, new .htaccess and update staging table prefix

### DIFF
--- a/assets/robots.txt
+++ b/assets/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/assets/staging-htaccess
+++ b/assets/staging-htaccess
@@ -1,0 +1,9 @@
+# BEGIN WordPress
+<IfModule mod_rewrite.c>
+RewriteEngine On
+RewriteBase {staging_name}
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule . /{staging_name}/index.php [L]
+</IfModule>
+# END WordPress

--- a/assets/staging-htaccess
+++ b/assets/staging-htaccess
@@ -1,7 +1,7 @@
 # BEGIN WordPress
 <IfModule mod_rewrite.c>
 RewriteEngine On
-RewriteBase {staging_name}
+RewriteBase /{staging_name}/
 RewriteCond %{REQUEST_FILENAME} !-f
 RewriteCond %{REQUEST_FILENAME} !-d
 RewriteRule . /{staging_name}/index.php [L]

--- a/includes/class-STL_File_Handling.php
+++ b/includes/class-STL_File_Handling.php
@@ -164,6 +164,35 @@ class STL_File_Handling {
 				copy( $source_file, $destination_file );
 			}
 		}
+
+		// Copy the robots.txt to staging.
+		if ( file_exists( STL_PLUGIN_PATH . 'assets/robots.txt' ) ) {
+			copy( STL_PLUGIN_PATH . 'assets/robots.txt', $target_directory . '/robots.txt' );
+		}
+
+		// Copy & Update the .htaccess file to staging.
+		if ( file_exists( STL_PLUGIN_PATH . 'assets/staging-htaccess' ) ) {
+			$data = file_get_contents( STL_PLUGIN_PATH . 'assets/staging-htaccess' );
+
+			if ( false !== $data ) {
+				$data = str_replace( '{staging_name}', $this->table_staging_name, $data );
+				file_put_contents( $target_directory . '/.htaccess', $data );
+			}
+		}
+
+		// Update staging wp-config.php file table prefix.
+		if ( file_exists( $target_directory . '/wp-config.php' ) ) {
+			$data = file_get_contents( $target_directory . '/wp-config.php' );
+
+			update_option( 'ETEST_PREFIX', $GLOBALS['wpdb']->base_prefix );
+			update_option( 'ETEST_ORIGINAL', "'" . $GLOBALS['wpdb']->base_prefix . "'" );
+			update_option( 'ETEST_NEW', "'" . $GLOBALS['wpdb']->base_prefix . $this->table_staging_name . "_'" );
+
+			if ( false !== $data ) {
+				$data = str_replace( "'" . $GLOBALS['wpdb']->base_prefix . "'", "'" . $GLOBALS['wpdb']->base_prefix . $this->table_staging_name . "_'", $data );
+				file_put_contents( $target_directory . '/wp-config.php', $data );
+			}
+		}
 	}
 
 }

--- a/includes/class-STL_File_Handling.php
+++ b/includes/class-STL_File_Handling.php
@@ -184,10 +184,6 @@ class STL_File_Handling {
 		if ( file_exists( $target_directory . '/wp-config.php' ) ) {
 			$data = file_get_contents( $target_directory . '/wp-config.php' );
 
-			update_option( 'ETEST_PREFIX', $GLOBALS['wpdb']->base_prefix );
-			update_option( 'ETEST_ORIGINAL', "'" . $GLOBALS['wpdb']->base_prefix . "'" );
-			update_option( 'ETEST_NEW', "'" . $GLOBALS['wpdb']->base_prefix . $this->table_staging_name . "_'" );
-
 			if ( false !== $data ) {
 				$data = str_replace( "'" . $GLOBALS['wpdb']->base_prefix . "'", "'" . $GLOBALS['wpdb']->base_prefix . $this->table_staging_name . "_'", $data );
 				file_put_contents( $target_directory . '/wp-config.php', $data );

--- a/includes/class-STL_File_Handling.php
+++ b/includes/class-STL_File_Handling.php
@@ -185,7 +185,13 @@ class STL_File_Handling {
 			$data = file_get_contents( $target_directory . '/wp-config.php' );
 
 			if ( false !== $data ) {
-				$data = str_replace( "'" . $GLOBALS['wpdb']->base_prefix . "'", "'" . $GLOBALS['wpdb']->base_prefix . $this->table_staging_name . "_'", $data );
+				$staging_url = site_url() . '/' . $this->table_staging_name;
+				$home     = "define( 'WP_HOME', '" . $staging_url . "' );";
+				$siteurl  = "define( 'WP_SITEURL', '" . $staging_url . "' );";
+				$env_type = "define( 'WP_ENVIRONMENT_TYPE', 'staging' );";
+				$data     = str_replace( "'" . $GLOBALS['wpdb']->base_prefix . "'", "'" . $GLOBALS['wpdb']->base_prefix . $this->table_staging_name . "_'", $data );
+				$data     = str_replace( "require_once ABSPATH . 'wp-settings.php';", $home . PHP_EOL . $siteurl . PHP_EOL . $env_type . PHP_EOL . "require_once ABSPATH . 'wp-settings.php';", $data );
+
 				file_put_contents( $target_directory . '/wp-config.php', $data );
 			}
 		}


### PR DESCRIPTION
- Copy over and setup `.htaccess` file in staging.
- Copy over `robots.txt` to staging.
- Set the `$table_prefix` for staging inside of `/staging/wp-config.php`.
- Set the following constants in the `wp-config.php` staging file.
   - `WP_HOME`
   - `WP_SITEURL`
   - `WP_ENVIRONMENT_TYPE`