### PR TITLE
Exclude robot.txt file and fix comparison in is_excluded

### DIFF
--- a/includes/class-stl-file-comparer.php
+++ b/includes/class-stl-file-comparer.php
@@ -69,6 +69,7 @@ class STL_File_Comparer {
         'wp-content/upgrade/',
         'wp-content/uploads/wp-staging/',
         '.htaccess',
+        'robots.txt',
         '.DS_Store',
         'error_log',
         'php_errorlog',
@@ -536,7 +537,7 @@ class STL_File_Comparer {
         
         // Check custom exclusions
         foreach ( $this->exclusions as $exclusion ) {
-            if ( 0 === strpos( $file, $exclusion ) || fnmatch( $exclusion, $file ) ) {
+            if ( false !== strpos( $file, $exclusion ) || fnmatch( $exclusion, $file ) ) {
                 return true;
             }
         }


### PR DESCRIPTION
 - Exclude Robots.txt.
 - Fix comparison in `is_excluded` to properly catch excluded file names.

_________

`strpos` return value:
> Returns the position of where the needle exists relative to the beginning of the haystack string (independent of offset). Also note that string positions start at 0, and not 1.
>
> Returns [false](https://www.php.net/manual/en/reserved.constants.php#constant.false) if the needle was not found.