### PR TITLE
Remove check for . as first character in file names

### DIFF
--- a/includes/class-STL_File_Handling.php
+++ b/includes/class-STL_File_Handling.php
@@ -48,7 +48,7 @@ class STL_File_Handling {
 			// Skip directories that are not files and skip hidden files and directories (starting with a dot)
 			// Skip directories starting with "cache" but allow files like "cache.php"
 			// But include the .htaccess file for copying
-			if ( $item->isDot() || ( '.' === $item->getFilename()[0] && '.htaccess' !== $item->getFilename()  ) || ( $item->isDir() && 0 === strpos( $item->getFilename(), 'cache' ) ) ) {
+			if ( $item->isDot() || ( $item->isDir() && 0 === strpos( $item->getFilename(), 'cache' ) ) ) {
 				continue;
 			}
 


### PR DESCRIPTION
Resolves #13 

The check that I've removed here was causing issues with certain themes/plugins. Specific files that started with a `.` weren't being copied over to the staging environment, and they were immediately listed in the table as deleted.  The `$item->isDot()` check we have should be enough to prevent `.` and `..` from being copied. Otherwise, we should be copying over `.` files, otherwise we are going to get improper results in what has changed between production and staging.

Some files that should be copied over but weren't:
- `.stylelintrc.json`
- `.stylelintignore`
- `.stylelintrc-css.json`
- `.stylelintrc.json`
