### PR TITLE
Remove the left margin from the success admin notice

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -508,6 +508,10 @@
     font-weight: bold;
 }
 
+#stl-sync-result-modal .stl-modal-body .notice-success {
+    margin-left: 0;
+}
+
 /* Responsive adjustments for image comparison */
 @media screen and (max-width: 782px) {
     .stl-image-container {


### PR DESCRIPTION
<img width="886" alt="image" src="https://github.com/user-attachments/assets/e1adbdc9-0908-449d-86e9-6dcf9825556d" />
